### PR TITLE
Add tests and helpers for full coverage

### DIFF
--- a/cmd/vnprider-node/main.go
+++ b/cmd/vnprider-node/main.go
@@ -21,6 +21,8 @@ import (
 
 var newLevelDBStore = storage.NewLevelDBStore
 var newHost = network.NewHost
+var runNodeFn = runNode
+var logFatal = log.Fatal
 
 func runNode(ctx context.Context) error {
 	cfg, err := internal.ParseConfig()
@@ -57,10 +59,10 @@ func runNode(ctx context.Context) error {
 func main() {
 	log.Println("vnprider-node starting...")
 	ctx := context.Background()
-	if err := runNode(ctx); err != nil {
+	if err := runNodeFn(ctx); err != nil {
 		if os.Getenv("TESTING") != "" {
 			panic(err)
 		}
-		log.Fatal(err)
+		logFatal(err)
 	}
 }

--- a/internal/config_test.go
+++ b/internal/config_test.go
@@ -61,6 +61,17 @@ func TestParseFileConfig(t *testing.T) {
 	}
 }
 
+func TestParseFileSkipLines(t *testing.T) {
+	os.WriteFile("skip.toml", []byte("\n#comment\ndata_dir=\"d\""), 0o644)
+	var c Config
+	if err := parseFile("skip.toml", &c); err != nil {
+		t.Fatal(err)
+	}
+	if c.DataDir != "d" {
+		t.Fatalf("expected d got %s", c.DataDir)
+	}
+}
+
 func TestParseFileErrors(t *testing.T) {
 	if err := parseFile("nofile.toml", &Config{}); err == nil {
 		t.Fatalf("expected error for missing file")


### PR DESCRIPTION
## Summary
- allow injecting runNode and logFatal in node main
- extend node tests for fatal and store error cases
- improve config parsing coverage

## Testing
- `bash scripts/test.sh`