### PR TITLE
Extend node tests

### DIFF
--- a/tests/integration/node_test.go
+++ b/tests/integration/node_test.go
@@ -1,23 +1,66 @@
-// Developed by DevPros with Codex as supporting tool
-// DO NOT EDIT MANUALLY
 package integration
 
 import (
+	"fmt"
+	"net"
 	"net/http"
-	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"testing"
-
-	"github.com/devprosvn/VNPrider/pkg/api"
+	"time"
 )
 
-func TestNodeStartup(t *testing.T) {
-	srv := httptest.NewServer(api.NewServer())
-	defer srv.Close()
-	resp, err := http.Get(srv.URL + "/status")
+func freePort(t *testing.T) int {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("unexpected status %d", resp.StatusCode)
+	defer l.Close()
+	return l.Addr().(*net.TCPAddr).Port
+}
+
+func waitServer(t *testing.T, addr string) {
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(addr + "/status")
+		if err == nil {
+			resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
+	t.Fatalf("server not ready: %s", addr)
+}
+
+func TestNodeEndToEnd(t *testing.T) {
+	dir := t.TempDir()
+	old, _ := os.Getwd()
+	defer os.Chdir(old)
+	os.Chdir(dir)
+
+	port := freePort(t)
+	cfg := fmt.Sprintf("data_dir=\"d\"\np2p.listen_port=0\nrpc.listen_port=%d", port)
+	os.WriteFile("config.toml", []byte(cfg), 0o644)
+	os.WriteFile("validators.toml", []byte("[validator]\nid=\"id1\"\npubkey=\"pk\"\nendpoint=\"ep\"\nweight=1"), 0o644)
+	os.WriteFile("security.toml", []byte("tls_cert_path=\"c\"\ntls_key_path=\"k\""), 0o644)
+
+	rootDir := filepath.Dir(filepath.Dir(old))
+	bin := filepath.Join(dir, "node")
+	build := exec.Command("go", "build", "-o", bin, "./cmd/vnprider-node")
+	build.Dir = rootDir
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build error: %v\n%s", err, out)
+	}
+
+	cmd := exec.Command(bin)
+	cmd.Dir = dir
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer cmd.Process.Kill()
+
+	waitServer(t, fmt.Sprintf("http://127.0.0.1:%d", port))
 }


### PR DESCRIPTION
## Summary
- expand node unit tests for port conflicts and p2p init errors
- add end-to-end integration test running compiled node binary

## Testing
- `bash scripts/test.sh`